### PR TITLE
Revert checkout to v2 and replace dockerhub org with altinityinfra org

### DIFF
--- a/.github/workflows/release_branches.yml
+++ b/.github/workflows/release_branches.yml
@@ -18,7 +18,7 @@ jobs:
         run: |
           sudo rm -fr "$GITHUB_WORKSPACE" && mkdir "$GITHUB_WORKSPACE"
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2
       - name: Images check
         run: |
           cd "$GITHUB_WORKSPACE/tests/ci"
@@ -35,7 +35,7 @@ jobs:
         run: |
           sudo rm -fr "$GITHUB_WORKSPACE" && mkdir "$GITHUB_WORKSPACE"
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2
       - name: Images check
         run: |
           cd "$GITHUB_WORKSPACE/tests/ci"
@@ -53,7 +53,7 @@ jobs:
         run: |
           sudo rm -fr "$GITHUB_WORKSPACE" && mkdir "$GITHUB_WORKSPACE"
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2
       - name: Download changed aarch64 images
         uses: actions/download-artifact@v2
         with:
@@ -88,7 +88,7 @@ jobs:
         run: |
           sudo rm -fr "$GITHUB_WORKSPACE" && mkdir "$GITHUB_WORKSPACE"
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2
       - name: Download json reports
         uses: actions/download-artifact@v2
         with:
@@ -131,7 +131,7 @@ jobs:
         run: |
           sudo rm -fr "$GITHUB_WORKSPACE" && mkdir "$GITHUB_WORKSPACE"
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2
         with:
           submodules: 'true'
           fetch-depth: 0 # otherwise we will have no info about contributors
@@ -176,7 +176,7 @@ jobs:
         run: |
           sudo rm -fr "$GITHUB_WORKSPACE" && mkdir "$GITHUB_WORKSPACE"
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2
       - name: Report Builder
         run: |
           sudo rm -fr "$TEMP_PATH"
@@ -213,7 +213,7 @@ jobs:
         run: |
           sudo rm -fr "$GITHUB_WORKSPACE" && mkdir "$GITHUB_WORKSPACE"
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2
       - name: Functional test
         run: |
           sudo rm -fr "$TEMP_PATH"
@@ -251,7 +251,7 @@ jobs:
         run: |
           sudo rm -fr "$GITHUB_WORKSPACE" && mkdir "$GITHUB_WORKSPACE"
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2
       - name: Functional test
         run: |
           sudo rm -fr "$TEMP_PATH"
@@ -290,7 +290,7 @@ jobs:
         run: |
           sudo rm -fr "$GITHUB_WORKSPACE" && mkdir "$GITHUB_WORKSPACE"
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2
       - name: Integration test
         run: |
           sudo rm -fr "$TEMP_PATH"
@@ -326,7 +326,7 @@ jobs:
         run: |
           sudo rm -fr "$GITHUB_WORKSPACE" && mkdir "$GITHUB_WORKSPACE"
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2
       - name: Integration test
         run: |
           sudo rm -fr "$TEMP_PATH"
@@ -355,7 +355,7 @@ jobs:
         run: |
           sudo rm -fr "$GITHUB_WORKSPACE" && mkdir "$GITHUB_WORKSPACE"
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2
       - name: Finish label
         run: |
           cd "$GITHUB_WORKSPACE/tests/ci"

--- a/docker/images.json
+++ b/docker/images.json
@@ -1,164 +1,164 @@
 {
     "docker/packager/deb": {
-        "name": "clickhouse/deb-builder",
+        "name": "altinityinfra/deb-builder",
         "dependent": []
     },
     "docker/packager/binary": {
-        "name": "clickhouse/binary-builder",
+        "name": "altinityinfra/binary-builder",
         "dependent": [
             "docker/test/split_build_smoke_test",
             "docker/test/codebrowser"
         ]
     },
     "docker/test/compatibility/centos": {
-        "name": "clickhouse/test-old-centos",
+        "name": "altinityinfra/test-old-centos",
         "dependent": []
     },
     "docker/test/compatibility/ubuntu": {
-        "name": "clickhouse/test-old-ubuntu",
+        "name": "altinityinfra/test-old-ubuntu",
         "dependent": []
     },
     "docker/test/integration/base": {
-        "name": "clickhouse/integration-test",
+        "name": "altinityinfra/integration-test",
         "dependent": []
     },
     "docker/test/fuzzer": {
-        "name": "clickhouse/fuzzer",
+        "name": "altinityinfra/fuzzer",
         "dependent": []
     },
     "docker/test/performance-comparison": {
-        "name": "clickhouse/performance-comparison",
+        "name": "altinityinfra/performance-comparison",
         "dependent": []
     },
     "docker/test/util": {
-        "name": "clickhouse/test-util",
+        "name": "altinityinfra/test-util",
         "dependent": [
             "docker/test/base",
             "docker/test/fasttest"
         ]
     },
     "docker/test/stateless": {
-        "name": "clickhouse/stateless-test",
+        "name": "altinityinfra/stateless-test",
         "dependent": [
             "docker/test/stateful",
             "docker/test/unit"
         ]
     },
     "docker/test/stateful": {
-        "name": "clickhouse/stateful-test",
+        "name": "altinityinfra/stateful-test",
         "dependent": [
             "docker/test/stress"
         ]
     },
     "docker/test/unit": {
-        "name": "clickhouse/unit-test",
+        "name": "altinityinfra/unit-test",
         "dependent": []
     },
     "docker/test/stress": {
-        "name": "clickhouse/stress-test",
+        "name": "altinityinfra/stress-test",
         "dependent": []
     },
     "docker/test/split_build_smoke_test": {
-        "name": "clickhouse/split-build-smoke-test",
+        "name": "altinityinfra/split-build-smoke-test",
         "dependent": []
     },
     "docker/test/codebrowser": {
-        "name": "clickhouse/codebrowser",
+        "name": "altinityinfra/codebrowser",
         "dependent": []
     },
     "docker/test/integration/runner": {
         "only_amd64": true,
-        "name": "clickhouse/integration-tests-runner",
+        "name": "altinityinfra/integration-tests-runner",
         "dependent": []
     },
     "docker/test/testflows/runner": {
-        "name": "clickhouse/testflows-runner",
+        "name": "altinityinfra/testflows-runner",
         "dependent": []
     },
     "docker/test/fasttest": {
-        "name": "clickhouse/fasttest",
+        "name": "altinityinfra/fasttest",
         "dependent": []
     },
     "docker/test/style": {
-        "name": "clickhouse/style-test",
+        "name": "altinityinfra/style-test",
         "dependent": []
     },
     "docker/test/integration/s3_proxy": {
-        "name": "clickhouse/s3-proxy",
+        "name": "altinityinfra/s3-proxy",
         "dependent": []
     },
     "docker/test/integration/resolver": {
-        "name": "clickhouse/python-bottle",
+        "name": "altinityinfra/python-bottle",
         "dependent": []
     },
     "docker/test/integration/helper_container": {
-        "name": "clickhouse/integration-helper",
+        "name": "altinityinfra/integration-helper",
         "dependent": []
     },
     "docker/test/integration/mysql_golang_client": {
-        "name": "clickhouse/mysql-golang-client",
+        "name": "altinityinfra/mysql-golang-client",
         "dependent": []
     },
     "docker/test/integration/dotnet_client": {
-        "name": "clickhouse/dotnet-client",
+        "name": "altinityinfra/dotnet-client",
         "dependent": []
     },
     "docker/test/integration/mysql_java_client": {
-        "name": "clickhouse/mysql-java-client",
+        "name": "altinityinfra/mysql-java-client",
         "dependent": []
     },
     "docker/test/integration/mysql_js_client": {
-        "name": "clickhouse/mysql-js-client",
+        "name": "altinityinfra/mysql-js-client",
         "dependent": []
     },
     "docker/test/integration/mysql_php_client": {
-        "name": "clickhouse/mysql-php-client",
+        "name": "altinityinfra/mysql-php-client",
         "dependent": []
     },
     "docker/test/integration/postgresql_java_client": {
-        "name": "clickhouse/postgresql-java-client",
+        "name": "altinityinfra/postgresql-java-client",
         "dependent": []
     },
     "docker/test/integration/kerberos_kdc": {
         "only_amd64": true,
-        "name": "clickhouse/kerberos-kdc",
+        "name": "altinityinfra/kerberos-kdc",
         "dependent": []
     },
     "docker/test/base": {
-         "name": "clickhouse/test-base",
-         "dependent": [
+        "name": "altinityinfra/test-base",
+        "dependent": [
             "docker/test/stateless",
             "docker/test/integration/base",
             "docker/test/fuzzer",
             "docker/test/keeper-jepsen"
-         ]
+        ]
     },
     "docker/test/integration/kerberized_hadoop": {
         "only_amd64": true,
-        "name": "clickhouse/kerberized-hadoop",
+        "name": "altinityinfra/kerberized-hadoop",
         "dependent": []
     },
     "docker/test/sqlancer": {
-        "name": "clickhouse/sqlancer-test",
+        "name": "altinityinfra/sqlancer-test",
         "dependent": []
     },
     "docker/test/keeper-jepsen": {
-        "name": "clickhouse/keeper-jepsen-test",
+        "name": "altinityinfra/keeper-jepsen-test",
         "dependent": []
     },
     "docker/docs/builder": {
-        "name": "clickhouse/docs-builder",
+        "name": "altinityinfra/docs-builder",
         "dependent": [
             "docker/docs/check",
             "docker/docs/release"
         ]
     },
     "docker/docs/check": {
-        "name": "clickhouse/docs-check",
+        "name": "altinityinfra/docs-check",
         "dependent": []
     },
     "docker/docs/release": {
-        "name": "clickhouse/docs-release",
+        "name": "altinityinfra/docs-release",
         "dependent": []
     }
 }


### PR DESCRIPTION
Changelog category (leave one):
- New Feature
- Improvement
- Bug Fix (user-visible misbehaviour in official stable or prestable release)
- Performance Improvement
- Backward Incompatible Change
- Build/Testing/Packaging Improvement
- Documentation (changelog entry is not required)
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...


> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
